### PR TITLE
fix changing a dependency mid-build

### DIFF
--- a/wsgiwatch.py
+++ b/wsgiwatch.py
@@ -33,12 +33,13 @@ class WSGIWatch:
             return run_process
 
     def __call__(self, environ, start_response):
+        lbt = time.time()
         with self.lock:
             for path, task in self.paths.items():
                 if path.last_modified() > self.last_build_time:
                     task()
 
-        self.last_build_time = time.time()
+        self.last_build_time = lbt
         return self.app(environ, start_response)
 
 class FilePath:


### PR DESCRIPTION
Fixes a bug where if you changed a dependency in the middle of a build, you'd have to `touch` it again in order to get it to rebuild when you refreshed the page a second time
